### PR TITLE
Fix sidebar support button

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -83,7 +83,11 @@ export function SidebarNavigation() {
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() => alert("Support")}
+              onClick={() =>
+                window.open(
+                  "mailto:support@prolog-app.com?subject=Support%20Request%3A%20",
+                )
+              }
             />
             <MenuItemButton
               text="Collapse"


### PR DESCRIPTION
Instead of an alert, it now opens the user's email client in a new browser tab with a prefilled email address and subject line.