### PR TITLE
Fixed the navigation logo size bug on mobile view

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import { useContext, useState } from "react";
+import { useContext, useState, useRef, useEffect } from "react";
 import { Routes } from "@config/routes";
 import classNames from "classnames";
 import { NavigationContext } from "./navigation-context";
@@ -20,6 +20,30 @@ export function SidebarNavigation() {
   const router = useRouter();
   const { isSidebarCollapsed, toggleSidebar } = useContext(NavigationContext);
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [headerWidth, setHeaderWidth] = useState(0);
+  const headerRef = useRef(null);
+
+  // Get the current width of the header element
+  const getHeaderWidth = () => {
+    if (headerRef.current) {
+      const element = headerRef.current as HTMLElement;
+      return element.getBoundingClientRect().width;
+    }
+    return 0;
+  };
+
+  // Check the width of the header element on resize
+  useEffect(() => {
+    const handleResize = () => {
+      const width = getHeaderWidth();
+      setHeaderWidth(width);
+    };
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
   return (
     <div
       className={classNames(
@@ -33,11 +57,11 @@ export function SidebarNavigation() {
           isSidebarCollapsed && styles.isCollapsed,
         )}
       >
-        <header className={styles.header}>
+        <header className={styles.header} ref={headerRef}>
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={
-              isSidebarCollapsed
+              isSidebarCollapsed && headerWidth < 100 // Set logo width based on header width
                 ? "/icons/logo-small.svg"
                 : "/icons/logo-large.svg"
             }


### PR DESCRIPTION
Added a resize event listener and headerWidth state to the sidebar navigation component. The header width value is checked by the logo icon and either renders the small or large logo depending.